### PR TITLE
fix: null equals in nested result

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -19,6 +19,10 @@ const items = [
         name: 'Developers',
       },
     ],
+    company: {
+      id: 1,
+      name: 'Earth',
+    },
   },
   {
     id: 2,
@@ -33,6 +37,7 @@ const items = [
         name: 'Developers',
       },
     ],
+    company: null,
   },
   {
     id: 3,
@@ -47,6 +52,10 @@ const items = [
         name: 'Users',
       },
     ],
+    company: {
+      id: 2,
+      name: 'Wind',
+    },
   },
 ];
 
@@ -380,6 +389,19 @@ describe('field has primitive', () => {
   });
   expect(result).toHaveLength(0);
 });
+
+describe('test nested field is null', () => {
+  const result = filter(items, {
+    company: {
+      name: {
+        _eq: 'Earth',
+      },
+    },
+  });
+  expect(result).toHaveLength(1);
+  expect(result[0]).toBe(items[0]);
+});
+
 //
 // describe('test', () => {
 //   const data = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,11 +68,29 @@ export function matchesFilter<T extends object>(
     }
     if (!(whereKey in item)) {
       if ('_is_null' in exp && exp['_is_null'] === true) {
+        // see test '_is_null is true on unknown field'
         continue;
       }
+      // see test 'unknown key'
       return false;
     }
     const itemValue = item[whereKey as keyof T];
+    if (itemValue === null || itemValue === undefined) {
+      if ('_is_null' in exp) {
+        if (exp['_is_null'] === true) {
+          // see test '_is_null is true on null field'
+          continue;
+        }
+      }
+      return false;
+    } else {
+      if ('_is_null' in exp) {
+        if (exp['_is_null'] === true) {
+          // see test '_is_null is true on non null field'
+          return false;
+        }
+      }
+    }
     if ('_eq' in exp) {
       if (!(itemValue === exp['_eq'])) {
         return false;
@@ -94,17 +112,6 @@ export function matchesFilter<T extends object>(
       }
       if (!exp['_in'].includes(itemValue)) {
         return false;
-      }
-    }
-    if ('_is_null' in exp) {
-      if (itemValue === null) {
-        if (exp['_is_null'] === false) {
-          return false;
-        }
-      } else {
-        if (exp['_is_null'] === true) {
-          return false;
-        }
       }
     }
     if ('_lt' in exp) {


### PR DESCRIPTION
If a response has a field set to null and an operation accesses this null field the filter should sort out this item.
e.g. the data

```json
[
    {
        "id": 1,
        "company": {
            "id": 1,
            "name": "Earth"
        }
    },
    {
        "id": 2,
        "company": null
    },
    {
        "id": 3,
        "company": {
            "id": 2,
            "name": "Wind"
        }
    }
]
```

with the filter
```json
{
    "company": {
        "name": {
            "_eq": "Earth"
        }
    }
}
```

should only return the item with id 1